### PR TITLE
core: Fix Pixel feature leaked to other apps

### DIFF
--- a/core/java/android/app/ApplicationPackageManager.java
+++ b/core/java/android/app/ApplicationPackageManager.java
@@ -811,7 +811,7 @@ public class ApplicationPackageManager extends PackageManager {
         String packageName = ActivityThread.currentPackageName();
         if (packageName != null &&
                 packageName.contains("com.google.android.apps.photos") &&
-                name.contains("PIXEL_2022_MIDYEAR_EXPERIENCE") ||
+                (name.contains("PIXEL_2022_MIDYEAR_EXPERIENCE") ||
                 name.contains("PIXEL_2021_EXPERIENCE") ||
                 name.contains("PIXEL_2021_MIDYEAR_EXPERIENCE") ||
                 name.contains("PIXEL_2020_EXPERIENCE") ||
@@ -820,7 +820,7 @@ public class ApplicationPackageManager extends PackageManager {
                 name.contains("PIXEL_2019_PRELOAD") ||
                 name.contains("PIXEL_2019_MIDYEAR_EXPERIENCE") ||
                 name.contains("PIXEL_2018_PRELOAD") ||
-                name.contains("PIXEL_2017_PRELOAD")) {
+                name.contains("PIXEL_2017_PRELOAD"))) {
             return false;
         }
         return mHasSystemFeatureCache.query(new HasSystemFeatureQuery(name, version));


### PR DESCRIPTION
* Current execution order is [1] `((A && B) && C) || (D) || (E) || (F) || (G)` and we want the execution order is [2] `A && B && (C || D || E || F || G)` If follow [1], it will not only affect GPhoto, but also Gcam, Gcam needs to read these functions or it will prompt for unsupported device and then crash

Change-Id: I53c97591fe7526c8dc6f07b914a43dc0f8b197b7